### PR TITLE
enforce maximum individual blob size as 1 byte

### DIFF
--- a/src/ecapnp_serialize.erl
+++ b/src/ecapnp_serialize.erl
@@ -89,6 +89,8 @@ pack_tag(Tag, <<>>, Acc) ->
 
 pack_blob(Data) -> pack_blob(0, Data).
 
+pack_blob(255, _) ->
+  255; % individual blob size can only be stored in 1 byte
 pack_blob(Count, <<Word:1/binary-unit:64, Rest/binary>>) ->
     case pack_tag(Word, <<>>) of
         {{C, _V}, _Tag} when C >= 6 ->


### PR DESCRIPTION
When `pack_blob` returned a count > 255 binary encoding for the count byte overflows and loops around to 0 when 256 and so on. This patch fixes that.

For anyone else reading and considering using this project, I haven't had any other issues with this library (yet), have a ton of quickcheck tests and state machines on my end, and won't be using RPC, so am quite happy to recommend it even though it hasn't been maintained recently. We are working on a large-scale project that will most probably be using this, so it's entirely possible I could at some point take over maintenance (if that is even necessary).
